### PR TITLE
Update golang installation to match the newer versions

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ So too many tasks can be blocked by the API for a certain time from github. In t
 ## Installation
 ### From go-get
 ```
-▶ GO111MODULE=on go install github.com/hahwul/gitls@latest
+▶ go install -v github.com/hahwul/gitls@latest
 ```
 ### Using homebres
 ```

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ So too many tasks can be blocked by the API for a certain time from github. In t
 ## Installation
 ### From go-get
 ```
-▶ GO111MODULE=on go get -v github.com/hahwul/gitls
+▶ GO111MODULE=on go install github.com/hahwul/gitls@latest
 ```
 ### Using homebres
 ```


### PR DESCRIPTION
- After golang updates, `go get` is no longer used outside modules, That breaks gitls installation, I updated it to use `go install` and `@latest` version as mentioned on golang documentation